### PR TITLE
Faulty error when using attribute macros in impl

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -239,7 +239,7 @@ fn parse_impl_template_impl(
                     TokenTree::Ident(ident) => {
                         parse_metavar(&mut iter, info, template, ident, is_repetition)?
                     }
-                    TokenTree::Group(group) => {
+                    TokenTree::Group(group) if group.delimiter() == Delimiter::Parenthesis => {
                         parse_metavar_repetition(&mut iter, info, template, group)?
                     }
                     _ => {


### PR DESCRIPTION
Hello, I was working with the `fortuples` macro and when using attribute macros in my impls, I was getting the error: "punctuation token is expected". For example:
```Rust
fortuples! {
    impl Foo for #Tuple {
        #[inline]
        fn foo() {
            ...
        }
    }
}
```
I tracked it down to parsing metavar repetitions and a check for the delimiter type fixes the faulty error. Some of the tests were already failing when I forked but those that were passing are still passing. Let me know if there's anything else I can do.